### PR TITLE
Add factor visualization CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 项目总览：alpha101_factory
 
 这是一个**可插拔（pluggable）Alpha 因子工厂**，围绕 A 股日线数据构建：
-**数据抓取（AkShare→BaoStock 兜底） → 特征缓存（tmp features） → 因子计算（Alpha101 & 更多） → 评价回测（IC/RankIC、分位组合） → 可视化与产物落盘（Parquet/PNG/CSV）**。
+**数据抓取（AkShare→Baostock 兜底） → 特征缓存（tmp features） → 因子计算（Alpha101 & 更多） → 评价回测（IC/RankIC、分位组合） → 可视化与产物落盘（Parquet/PNG/CSV）**。
 核心目标：让新人“拿来即用”，也能“随插随扩”。
 
 ---
@@ -16,7 +16,7 @@
 ├── cli.py                   # 顶层命令行：fetch / fetch-one / tmp / factor / check
 ├── config.py                # 目录/环境变量/采样/速率限制/图像路径
 ├── data                     # 数据获取与装载
-│   ├── baostock_api.py      # BaoStock 封装（akshare 失败时兜底）
+│   ├── baostock_api.py      # Baostock 封装（akshare 失败时兜底）
 │   ├── loader.py            # 抓取Spot/K线、校验、读取本地或下载、保存K线图片
 │   └── universe.py          # 股票池定义（可按需改造）
 ├── factors                  # 因子体系
@@ -45,7 +45,7 @@
 
    * `data/loader.py`
 
-     * 优先用 **AkShare** 获取；失败自动改用 **BaoStock**。
+     * 优先用 **AkShare** 获取；失败自动改用 **Baostock**。
      * 生成：
 
        * `data/spot/a_spot.parquet`（行情快照）
@@ -100,9 +100,9 @@
 * `START_DATE / END_DATE`：全局抓取范围（也可用 `fetch-one --start/--end` 临时覆盖）
 * `LIMIT_STOCKS`：调试时限制股票数量
 * `REQUEST_PAUSE`：抓取节流
-* 图片目录：`images/klines`、`images/backtest`
+* 图片目录：`images/klines`、`images/backtest`、`images/factors/*`
 
-### B. 数据获取（AkShare→BaoStock 兜底）
+### B. 数据获取（AkShare→Baostock 兜底）
 
 * `loader._fetch_kline_fallback()`：先 akshare，异常/空数据 → `baostock_api.fetch_kline_bs()`
 * 读取本地 Parquet 时支持**日期裁剪**；无本地即下载。
@@ -154,6 +154,9 @@ python -m alpha101_factory.cli factor --factors Alpha101 --stock 600000
 
 # 4) 回测评估（会自动从 factors/*.parquet + klines 读取）
 python -m alpha101_factory.backtest.run_bt --alpha Alpha101 --horizon 1 --quantiles 5
+
+# 5) 因子可视化（批量输出时间序列/截面/热力图到 images/factors）
+python -m alpha101_factory.cli visualize --all --prefix Alpha
 ```
 
 > Colab 可用同样命令；注意 `kaleido` 负责把 Plotly figure 存为 PNG。
@@ -206,7 +209,7 @@ python -m alpha101_factory.backtest.run_bt --alpha Alpha101 --horizon 1 --quanti
 * **K 线横轴是 1.6e18？**
   已在 `viz/plots.py` 强制把任何输入类型转为 `datetime` 并设置 `xaxis.type='date'`，PNG 正常显示 `%Y-%m-%d` 且 -45°。
 * **AkShare 拉不下来？**
-  自动切 BaoStock；也可手动只跑 `fetch-one` 做单票验证。
+  自动切 Baostock；也可手动只跑 `fetch-one` 做单票验证。
 
 ---
 

--- a/alpha101_factory/config.py
+++ b/alpha101_factory/config.py
@@ -14,9 +14,25 @@ LOG_DIR         = DATA_ROOT / "logs"
 IMG_DIR         = DATA_ROOT / "images"
 IMG_KLINES_DIR  = IMG_DIR / "klines"
 IMG_BT_DIR      = IMG_DIR / "backtest"
+IMG_FACTORS_DIR = IMG_DIR / "factors"
+IMG_FACTORS_TS_DIR = IMG_FACTORS_DIR / "timeseries"
+IMG_FACTORS_CS_DIR = IMG_FACTORS_DIR / "cross_section"
+IMG_FACTORS_HEATMAP_DIR = IMG_FACTORS_DIR / "heatmap"
 
-for p in [PARQ_DIR_SPOT, PARQ_DIR_KLINES, PARQ_DIR_TMP, PARQ_DIR_FACT,
-          LOG_DIR, IMG_DIR, IMG_KLINES_DIR, IMG_BT_DIR]:
+for p in [
+    PARQ_DIR_SPOT,
+    PARQ_DIR_KLINES,
+    PARQ_DIR_TMP,
+    PARQ_DIR_FACT,
+    LOG_DIR,
+    IMG_DIR,
+    IMG_KLINES_DIR,
+    IMG_BT_DIR,
+    IMG_FACTORS_DIR,
+    IMG_FACTORS_TS_DIR,
+    IMG_FACTORS_CS_DIR,
+    IMG_FACTORS_HEATMAP_DIR,
+]:
     p.mkdir(parents=True, exist_ok=True)
 
 # AkShare K 线参数

--- a/alpha101_factory/viz/factor_summary.py
+++ b/alpha101_factory/viz/factor_summary.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+"""高层因子可视化入口。
+
+该模块负责读取 `PARQ_DIR_FACT` 下的因子结果，并生成默认的三类图像：
+
+1. 单只股票的因子时间序列；
+2. 最新交易日的截面分布；
+3. 热力图（时间 × 股票）。
+
+所有图像会保存至 ``images/factors`` 目录的子文件夹中，也可以在测试
+场景中通过 ``save=False`` 仅返回 ``plotly`` 图形对象以便断言。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Mapping, MutableMapping, Optional, Sequence
+
+import pandas as pd
+from loguru import logger
+
+from alpha101_factory.config import (
+    IMG_FACTORS_CS_DIR,
+    IMG_FACTORS_HEATMAP_DIR,
+    IMG_FACTORS_TS_DIR,
+    PARQ_DIR_FACT,
+)
+from alpha101_factory.utils.io import read_parquet
+from alpha101_factory.viz.plots import (
+    plot_factor_cross_section,
+    plot_factor_timeseries,
+    plot_heatmap,
+    save_fig,
+)
+
+
+@dataclass
+class FactorVisualArtifacts:
+    """封装单个因子的可视化产物信息。"""
+
+    factor: str
+    ts_symbol: Optional[str]
+    cross_section_dt: Optional[pd.Timestamp]
+    outputs: MutableMapping[str, Path | object]
+
+
+def _coerce_datetime(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    if "datetime" in df.columns:
+        df["datetime"] = pd.to_datetime(df["datetime"], errors="coerce")
+    return df.dropna(subset=["datetime", "symbol", "value"], how="any")
+
+
+def _select_symbol(df: pd.DataFrame, preferred: Optional[str]) -> Optional[str]:
+    if df.empty:
+        return None
+    symbols = sorted(df["symbol"].dropna().unique())
+    if not symbols:
+        return None
+    if preferred and preferred in symbols:
+        return preferred
+    if preferred and preferred not in symbols:
+        logger.warning(
+            "首选标的 {symbol} 在因子数据中缺失，自动改用 {fallback}",
+            symbol=preferred,
+            fallback=symbols[0],
+        )
+    return symbols[0]
+
+
+def _select_heatmap_symbols(
+    df: pd.DataFrame, heatmap_symbols: Optional[Sequence[str]], max_count: int
+) -> List[str]:
+    if df.empty:
+        return []
+
+    all_counts = df["symbol"].value_counts()
+    if heatmap_symbols:
+        filtered = [s for s in heatmap_symbols if s in all_counts.index]
+        if filtered:
+            return filtered[:max_count]
+        logger.warning(
+            "指定的热力图股票全部缺失，将改用覆盖度最高的 {count} 只", count=max_count
+        )
+
+    return list(all_counts.head(max_count).index)
+
+
+def _load_factor_frame(factor_name: str) -> pd.DataFrame:
+    path = PARQ_DIR_FACT / f"{factor_name}.parquet"
+    if not path.exists():
+        raise FileNotFoundError(path)
+    df = read_parquet(path)
+    if df is None:
+        return pd.DataFrame(columns=["datetime", "symbol", "value"])
+    return df
+
+
+def generate_factor_visuals(
+    factor_name: str,
+    *,
+    frame: Optional[pd.DataFrame] = None,
+    ts_symbol: Optional[str] = None,
+    heatmap_symbols: Optional[Sequence[str]] = None,
+    cross_section_dt: Optional[pd.Timestamp] = None,
+    heatmap_top: int = 12,
+    save: bool = True,
+) -> FactorVisualArtifacts:
+    """为单个因子生成可视化。"""
+
+    if frame is None:
+        try:
+            frame = _load_factor_frame(factor_name)
+        except FileNotFoundError as exc:
+            logger.error("未找到因子 {factor} 的结果文件: {path}", factor=factor_name, path=exc)
+            return FactorVisualArtifacts(factor_name, None, None, {})
+
+    df = _coerce_datetime(frame)
+    if df.empty:
+        logger.error("因子 %s 无有效数据，跳过绘图", factor_name)
+        return FactorVisualArtifacts(factor_name, None, None, {})
+
+    symbol = _select_symbol(df, ts_symbol)
+    if symbol is None:
+        logger.error("因子 %s 没有可用于时间序列的标的", factor_name)
+        return FactorVisualArtifacts(factor_name, None, None, {})
+
+    dt = cross_section_dt
+    if dt is None:
+        dt = pd.to_datetime(df["datetime"]).max()
+
+    heatmap_list = _select_heatmap_symbols(df, heatmap_symbols, heatmap_top)
+
+    outputs: MutableMapping[str, Path | object] = {}
+
+    ts_fig = plot_factor_timeseries(df, symbol=symbol, title=factor_name)
+    cs_fig = plot_factor_cross_section(df, dt=dt, title=factor_name)
+    heat_fig = None
+    if heatmap_list:
+        heat_fig = plot_heatmap(df, symbols=heatmap_list, title=factor_name)
+    else:
+        logger.warning("因子 %s 无法生成热力图，缺少足够的股票样本。", factor_name)
+
+    if save:
+        ts_path = IMG_FACTORS_TS_DIR / f"{factor_name}_{symbol}.png"
+        cs_suffix = pd.to_datetime(dt).strftime("%Y%m%d") if pd.notna(dt) else "latest"
+        cs_path = IMG_FACTORS_CS_DIR / f"{factor_name}_{cs_suffix}.png"
+        heat_name = "_".join(heatmap_list[:5]) or "all"
+        heat_path = IMG_FACTORS_HEATMAP_DIR / f"{factor_name}_{heat_name}.png"
+
+        outputs["timeseries"] = save_fig(ts_fig, ts_path)
+        outputs["cross_section"] = save_fig(cs_fig, cs_path)
+        if heat_fig is not None:
+            outputs["heatmap"] = save_fig(heat_fig, heat_path)
+    else:
+        outputs["timeseries"] = ts_fig
+        outputs["cross_section"] = cs_fig
+        if heat_fig is not None:
+            outputs["heatmap"] = heat_fig
+
+    return FactorVisualArtifacts(factor_name, symbol, pd.to_datetime(dt), outputs)
+
+
+def _discover_factor_names(prefix: str = "Alpha") -> List[str]:
+    files = sorted(PARQ_DIR_FACT.glob("*.parquet"))
+    names = [p.stem for p in files if not prefix or p.stem.startswith(prefix)]
+    return names
+
+
+def generate_all_factor_visuals(
+    *,
+    factors: Optional[Sequence[str]] = None,
+    prefix: str = "Alpha",
+    ts_symbol: Optional[str] = None,
+    heatmap_symbols: Optional[Sequence[str]] = None,
+    heatmap_top: int = 12,
+    limit: Optional[int] = None,
+    save: bool = True,
+) -> Mapping[str, FactorVisualArtifacts]:
+    """批量渲染多个因子的可视化。"""
+
+    if factors is None or not factors:
+        factors = _discover_factor_names(prefix)
+
+    if limit is not None and limit > 0:
+        factors = list(factors)[:limit]
+
+    results: MutableMapping[str, FactorVisualArtifacts] = {}
+
+    for name in factors:
+        art = generate_factor_visuals(
+            name,
+            ts_symbol=ts_symbol,
+            heatmap_symbols=heatmap_symbols,
+            heatmap_top=heatmap_top,
+            save=save,
+        )
+        if art.outputs:
+            results[name] = art
+    return results
+
+
+__all__ = [
+    "FactorVisualArtifacts",
+    "generate_factor_visuals",
+    "generate_all_factor_visuals",
+]
+

--- a/tests/test_factor_visuals.py
+++ b/tests/test_factor_visuals.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+import sys
+from pathlib import Path
+
+import pandas as pd
+import plotly.graph_objects as go
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from alpha101_factory.config import PARQ_DIR_FACT
+from alpha101_factory.viz.factor_summary import (
+    generate_all_factor_visuals,
+    generate_factor_visuals,
+)
+
+
+def _sample_frame():
+    dates = pd.date_range("2021-01-01", periods=6, freq="D")
+    symbols = ["000001", "000002", "000003"]
+    rows = []
+    for dt in dates:
+        for idx, sym in enumerate(symbols):
+            rows.append({
+                "datetime": dt,
+                "symbol": sym,
+                "value": (idx + 1) * 0.1 + dt.day / 100,
+            })
+    return pd.DataFrame(rows)
+
+
+def test_generate_factor_visuals_returns_figures():
+    df = _sample_frame()
+
+    art = generate_factor_visuals("AlphaTest", frame=df, save=False, heatmap_top=2)
+
+    assert art.factor == "AlphaTest"
+    assert art.ts_symbol == "000001"
+    assert isinstance(art.outputs["timeseries"], go.Figure)
+    assert isinstance(art.outputs["cross_section"], go.Figure)
+    assert "heatmap" in art.outputs
+    assert isinstance(art.outputs["heatmap"], go.Figure)
+    assert art.cross_section_dt == pd.Timestamp("2021-01-06")
+
+
+def test_generate_all_factor_visuals_reads_parquet():
+    df = _sample_frame()
+    path = PARQ_DIR_FACT / "AlphaVisual.parquet"
+    df.to_parquet(path, index=False)
+
+    try:
+        res = generate_all_factor_visuals(factors=["AlphaVisual"], save=False)
+        assert "AlphaVisual" in res
+        assert res["AlphaVisual"].ts_symbol == "000001"
+        assert "heatmap" in res["AlphaVisual"].outputs
+        assert isinstance(res["AlphaVisual"].outputs["heatmap"], go.Figure)
+    finally:
+        if path.exists():
+            path.unlink()

--- a/tests/test_loader_paths.py
+++ b/tests/test_loader_paths.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from alpha101_factory.data import loader
+
+
+def test_resolve_kline_path_full_range(tmp_path, monkeypatch):
+    monkeypatch.setattr(loader, "PARQ_DIR_KLINES", tmp_path)
+    path = loader._resolve_kline_path("sh600000", "20200101", "20210101", "hfq")
+    assert path == tmp_path / "600000_20200101_20210101_hfq.parquet"
+
+
+def test_resolve_kline_path_without_range(tmp_path, monkeypatch):
+    monkeypatch.setattr(loader, "PARQ_DIR_KLINES", tmp_path)
+    path = loader._resolve_kline_path("600000", "", None, "qfq")
+    assert path == tmp_path / "600000.parquet"


### PR DESCRIPTION
## Summary
- add a CLI `visualize` command that renders time-series, cross-section, and heatmap plots for saved factors
- create a factor visualization helper that saves outputs under a dedicated images/factors hierarchy
- expand documentation and tests to cover the visualization workflow and directory scaffolding

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da4240b8a483288f9f8586cd75dabc